### PR TITLE
Strip control chars from JSON response

### DIFF
--- a/stmemory.js
+++ b/stmemory.js
@@ -418,7 +418,7 @@ function normalizeText(s) {
     return String(s)
         .replace(/\r\n/g, '\n')
         .replace(/^\uFEFF/, '')
-        .replace(/[\u200B-\u200D\u2060]/g, '');
+        .replace(/[\u0000-\u001F\u200B-\u200D\u2060]/g, '');
 }
 
 function extractFencedBlocks(s) {


### PR DESCRIPTION
I've noticed that a frequent cause of failures in JSON parsing comes from the presence of control characters in the unparsed text. This attempts to fix that, by adding these control chars to the normalizeText stripping function