### PR TITLE
Fix: strip C0 control characters in arcanalysis.js normalizeText (bring in line with stmemory.js)

### DIFF
--- a/arcanalysis.js
+++ b/arcanalysis.js
@@ -53,8 +53,14 @@ function normalizeText(s) {
   return String(s || "")
     .replace(/\r\n/g, "\n")
     .replace(/^\uFEFF/, "")
-    .replace(/[\u200B-\u200D\u2060]/g, "");
-}
+    .replace(/[\u200B-\u200D\u2060]/g, "")
+   // Strip stray C0 control characters (e.g. SOH, STX) that some models
+   // occasionally emit as decoding artifacts. These are invalid unescaped
+   // inside JSON strings and currently cause JSON.parse to fail with no
+   // indication of the actual cause. Matches the stripping already done
+   // in stmemory.js's normalizeText for consistency between pipelines.
+    .replace(/[\u0000-\u001F\u200B-\u200D\u2060]/g, "");
+  }
 
 function extractFencedBlocks(s) {
   const re = /```([\w+-]*)\s*([\s\S]*?)```/g;


### PR DESCRIPTION
**Fix: strip C0 control characters in `arcanalysis.js` normalizeText (bring in line with stmemory.js)**

### What
Consolidation (Arc analysis) can fail with `"Model did not return valid arc JSON"` even when the model's response is otherwise well-formed. The cause is stray C0 control characters (e.g. a literal SOH / `0x01` byte) embedded in the raw response — likely a decoding artifact on the model/provider side. A raw, unescaped control character inside a JSON string is invalid per spec, so every parse candidate in `parseSummaryJsonResponse()` fails, surfacing a generic error with no indication of the real cause.

### Why this fix
`stmemory.js` has its own copy of `normalizeText()`, used for regular scene/catchup memory creation, and it already strips the full C0 control range:

```js
.replace(/[\u0000-\u001F\u200B-\u200D\u2060]/g, '');
```

`arcanalysis.js`'s copy of the same function only strips a BOM and zero-width characters. The two clearly share a common origin but diverged — this PR just brings `arcanalysis.js` in line with the protection `stmemory.js` already has, rather than introducing new logic.

### Change
Added the C0 control-character strip as a separate, commented step in `arcanalysis.js`'s `normalizeText()`, rather than folding it into the existing zero-width-character regex, so it's easy to isolate/revert independently if needed.

### Testing
Verified locally on 8.3.2 (main-68aa4ac): reproduced the failure on a consolidation response containing a stray control byte, confirmed the patched `normalizeText()` resolves it and consolidation completes normally.

### Possible follow-up (not included in this PR)
`normalizeText()` is now duplicated near-identically across two files. Could be worth extracting to a shared module so the two pipelines can't silently diverge like this again — happy to open a separate PR for that if it's wanted.